### PR TITLE
Updated version of jquery-ui-rails

### DIFF
--- a/jquery-ui-sass-rails.gemspec
+++ b/jquery-ui-sass-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", ">= 3.1.0"
   s.add_dependency "jquery-rails"
-  s.add_dependency "jquery-ui-rails", "~> #{Jquery::Ui::Sass::Rails::JQUERY_UI_RAILS_VERSION}"
+  s.add_dependency "jquery-ui-rails", ">= #{Jquery::Ui::Sass::Rails::JQUERY_UI_RAILS_VERSION}"
 
   s.add_development_dependency "json", "~> 1.7"
 


### PR DESCRIPTION
I wanted to use `jquery-ui-sass-rails` in the project which uses also `activeadmin` and I encountered this issue:

```
ania Animac:~/projects/startpace :) [develop] $ bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "jquery-ui-rails":
  In Gemfile:
    jquery-ui-sass-rails (>= 0) ruby depends on
      jquery-ui-rails (= 4.0.2) ruby

    activeadmin (>= 0) ruby depends on
      jquery-ui-rails (5.0.3)
```

So I changed dependency in the `gemspec`.
It works for me, but not sure how to test if it it don't break something else.
